### PR TITLE
Update compat for PlutoSliderServer to 1.0.0

### DIFF
--- a/.github/workflows/ExportPluto.yaml
+++ b/.github/workflows/ExportPluto.yaml
@@ -16,21 +16,21 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout this repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: Install Julia
-              uses: julia-actions/setup-julia@v1
+              uses: julia-actions/setup-julia@v2
               with:
                   version: "1" # This will automatically pick the latest Julia version
 
             - name: Cache Julia artifacts & such
-              uses: julia-actions/cache@v1
+              uses: julia-actions/cache@v2
               with:
                 cache-registries: "true"
 
             # We set up a folder that Pluto can use to cache exported notebooks. If the notebook file did not change, then Pluto can take the exported file from cache instead of running the notebook.
             - name: Set up notebook state cache
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               with:
                   path: pluto_state_cache
                   key: ${{ runner.os }}-pluto_state_cache-v2-${{ hashFiles('**/Project.toml', '**/Manifest.toml', '.github/workflows/*' ) }}-${{ hashFiles('**/*jl') }}
@@ -46,7 +46,7 @@ jobs:
                 julia -e 'using Pkg
                   Pkg.activate(mktempdir())
                   Pkg.add([
-                    Pkg.PackageSpec(name="PlutoSliderServer", version="0.3.2-0.3"),
+                    Pkg.PackageSpec(name="PlutoSliderServer", version="1"),
                   ])
 
                   import PlutoSliderServer


### PR DESCRIPTION
Hi! This is an automatic PR to update the PlutoSliderServer compat from 0.3 to 1.0.0! I did not test this PR, but PlutoSliderServer 1.0.0 had no breaking changes, except the new Julia 1.10 minimum ([release notes](https://github.com/JuliaPluto/PlutoSliderServer.jl/releases/tag/v1.0.0)).